### PR TITLE
Support JDKW_BASE_DIR from Command Line or Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ JDKW_BUILD=b11
 JDKW_TOKEN=d54c1d3a095b4ff2b6607d096fa80163
 ```
 
+You can override the directory by specifying the `JDKW_BASE_DIR` configuration either in the environment or on the command line. Since this
+value controls where to find the the `.jdkw` file it is the only configuration value that cannot be loaded from a file. For example:
+
+    > ./jdk-wrapper.sh JDKW_BASE_DIR=/usr/local/etc <CMD>
+
 Lastly, you can also specify configuration values in a `.jdkw` file in your home directory for per-user configuration (e.g. for OTN credentials).
 
 ```
@@ -102,7 +107,8 @@ Finally, any combination of these four forms of configuration is permissible. Th
 1) Command Line
 2) Environment
 3) .jdkw (working directory)
-4) ~/.jdkw (home directory)
+4) .jdkw (`jdk-wrapper.sh` directory)
+5) ~/.jdkw (home directory)
 
 The wrapper script will download and cache the specified JDK version and set `JAVA_HOME` appropriately before executing the specified command.
 
@@ -144,6 +150,13 @@ ignored for JDK 9. The `JDKW_JCE` flag only applies if `JDKW_DIST` is oracle.
 **IMPORTANT**: The `JDKW_TOKEN` is required for oracle release 8u121-b13 and newer
 except it is not required for oracle release JDK 9.0.1 but is required for
 other JDK 9 releases (as of 2/4/18). `JDKW_TOKEN` does not apply to zulu.
+
+Additionally, there is the `JDKW_BASE_DIR` configuration value which is only loaded
+from the environment or command line with the command line value having higher
+precedence. This configuration value overrides the path where to locate the
+`.jdkw` file which by default is the current working directory. This is useful
+in situations where you cannot `cd` into the project directory or if you have
+a shared `.jdkw` file for multiple projects.
 
 ### Version and Build
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,11 @@
 JDK Wrapper Release Notes
 =========================
 
+0.11.0 - June 3, 2018
+------------------------
+* Added configuration support for base directory where to locate .jdkw by default in the current working directory
+* Tightened argument matching regular expressions to improve correctness and performance
+
 0.10.0 - May 3, 2018
 ------------------------
 * Added official support for Windows under Cygwin, Msys and WSL

--- a/jdk-wrapper.sh
+++ b/jdk-wrapper.sh
@@ -77,36 +77,36 @@ download_if_needed() {
 # Default curl options
 curl_options=""
 
-# Load properties file in home directory
-if [ -f "${HOME}/.jdkw" ]; then
-  . "${HOME}/.jdkw"
-fi
-
-# Load properties file in working directory
-if [ -f ".jdkw" ]; then
-  . "./.jdkw"
-fi
-
-# Load properties from environment
+# Process (but do not load) properties from environment
+env_configuration=
 l_fifo="${TMPDIR:-/tmp}/$$.$(rand)"
 safe_command "mkfifo \"${l_fifo}\""
 env > "${l_fifo}" &
 while IFS='=' read -r name value
 do
-  jdkw_arg=$(echo "${name}" | grep 'JDKW_.*')
-  if [ -n "${jdkw_arg}" ]; then
+  jdkw_arg=$(echo "${name}" | grep '^JDKW_.*')
+  jdkw_base_dir_arg=$(echo "${name}" | grep '^JDKW_BASE_DIR')
+  if [ -n "${jdkw_base_dir_arg}" ]; then
     eval "${name}=\"${value}\""
+  fi
+  if [ -n "${jdkw_arg}" ]; then
+    env_configuration="${env_configuration}${name}=\"${value}\" "
   fi
 done < "${l_fifo}"
 safe_command "rm \"${l_fifo}\""
 
-# Load properties from command line arguments
+# Process (but do not load) properties from command line arguments
 command=
+cmd_configuration=
 for arg in "$@"; do
   if [ -z ${in_command} ]; then
-    jdkw_arg=$(echo "${arg}" | grep 'JDKW_.*')
-    if [ -n "${jdkw_arg}" ]; then
+    jdkw_arg=$(echo "${arg}" | grep '^JDKW_.*')
+    jdkw_base_dir_arg=$(echo "${arg}" | grep '^JDKW_BASE_DIR.*')
+    if [ -n "${jdkw_base_dir_arg}" ]; then
       eval ${arg}
+    fi
+    if [ -n "${jdkw_arg}" ]; then
+      cmd_configuration="${cmd_configuration}${arg} "
     fi
   fi
   case "${arg}" in
@@ -117,6 +117,27 @@ for arg in "$@"; do
   esac
   command="${command} '${arg}'"
 done
+
+# Default base directory to current working directory
+if [ -z "${JDKW_BASE_DIR}" ]; then
+    JDKW_BASE_DIR="."
+fi
+
+# Load properties file in home directory
+if [ -f "${HOME}/.jdkw" ]; then
+  . "${HOME}/.jdkw"
+fi
+
+# Load properties file in base directory
+if [ -f "${JDKW_BASE_DIR}/.jdkw" ]; then
+  . "${JDKW_BASE_DIR}/.jdkw"
+fi
+
+# Load properties from environment
+eval "${env_configuration}"
+
+# Load properties from command line arguments
+eval "${cmd_configuration}"
 
 # Process configuration
 if [ -z "${JDKW_BASE_URI}" ]; then


### PR DESCRIPTION
Added suport to override the working directory where the .jdkw file is located by specifying JDKW_BASE_DIR either in the environment or on the command line.

This addresses #21.