### PR TITLE
redirect diagnostic output / logging to stderr

### DIFF
--- a/jdk-wrapper.sh
+++ b/jdk-wrapper.sh
@@ -25,7 +25,7 @@ log_err() {
 log_out() {
   if [ -n "${JDKW_VERBOSE}" ]; then
     l_prefix=$(date  +'%H:%M:%S')
-    printf "[%s] %s\\n" "${l_prefix}" "$@"
+    printf "[%s] %s\\n" "${l_prefix}" "$@" 1>&2;
   fi
 }
 

--- a/jdkw-impl.sh
+++ b/jdkw-impl.sh
@@ -25,7 +25,7 @@ log_err() {
 log_out() {
   if [ -n "${JDKW_VERBOSE}" ]; then
     l_prefix=$(date  +'%H:%M:%S')
-    printf "[%s] %s\\n" "${l_prefix}" "$@"
+    printf "[%s] %s\\n" "${l_prefix}" "$@" 1>&2;
   fi
 }
 
@@ -678,7 +678,7 @@ fi
 # Setup the environment
 log_out "Environment:"
 if [ -n "${JDKW_VERBOSE}" ]; then
-  cat "${JDKW_TARGET}/${jdkid}/environment"
+  cat "${JDKW_TARGET}/${jdkid}/environment" 1>&2
 fi
 . "${JDKW_TARGET}/${jdkid}/environment"
 


### PR DESCRIPTION
I want to have verbose logging enabled, but I still want to only capture the output of the wrapped command.

e.g.
```bash
$ out=$(JDKW_VERBOSE=1 ./jdk-wrapper.sh echo ok)
$ echo $out
ok
```

**Expectation**: The above prints ok

**Observed**: The above includes all of the logging from jdk-wrapper

I redirected the remaining logging commands that still printed to stdout.